### PR TITLE
new parameters fallback_css, fallback_js

### DIFF
--- a/jscssminifyghsvs.php
+++ b/jscssminifyghsvs.php
@@ -195,23 +195,23 @@ class PlgSystemJsCssMinifyGhsvs extends JPlugin
        }
       } // preserve_first_comment
 
-						// 2017-09 for fallback behavior.
-						$content_tmp = $content;
-						
+      // 2017-09 for fallback behavior.
+      $content_tmp = $content;
+      
       // Get minified target content from web service sending source content.
       if (!($content = self::getMinified($url, $content_tmp)))
       {
        $errors[] = JText::sprintf('PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY', $url, $file_);
-							if ($this->params->get('fallback_' . $what, 0))
-							{
-								$content = $content_tmp;
-								$errors[] = JText::_('PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY_FALLBACK');
-								unset($content_tmp);
-							}
-							else
-							{
+       if ($this->params->get('fallback_' . $what, 0))
+       {
+        $content = $content_tmp;
+        $errors[] = JText::_('PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY_FALLBACK');
+        unset($content_tmp);
+       }
+       else
+       {
         continue;
-							}
+       }
       }
 
       // Create target path plus "secure" file name if no target in file-set entered.

--- a/jscssminifyghsvs.php
+++ b/jscssminifyghsvs.php
@@ -195,13 +195,25 @@ class PlgSystemJsCssMinifyGhsvs extends JPlugin
        }
       } // preserve_first_comment
 
+						// 2017-09 for fallback behavior.
+						$content_tmp = $content;
+						
       // Get minified target content from web service sending source content.
-      if (!($content = self::getMinified($url, $content)))
+      if (!($content = self::getMinified($url, $content_tmp)))
       {
        $errors[] = JText::sprintf('PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY', $url, $file_);
-       continue;
+							if ($this->params->get('fallback_' . $what, 0))
+							{
+								$content = $content_tmp;
+								$errors[] = JText::_('PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY_FALLBACK');
+								unset($content_tmp);
+							}
+							else
+							{
+        continue;
+							}
       }
-      
+
       // Create target path plus "secure" file name if no target in file-set entered.
       if (!($file->target = trim($file->target)))
       {

--- a/jscssminifyghsvs.xml
+++ b/jscssminifyghsvs.xml
@@ -7,7 +7,7 @@
  <license>GNU General Public License version 3 or later; see LICENSE.txt</license>
  <authorEmail>jscssminifyghsvs @ ghsvs.de</authorEmail>
  <authorUrl>http://www.ghsvs.de</authorUrl>
- <version>2017-07-28</version>
+ <version>2017.09.11</version>
  <versionHistory>
 2016.03.09:
 - Start Plugin System jscssminifyghsvs
@@ -32,6 +32,8 @@
 2017-07-28:
 - Remove own subform because ordering fails since B\C break in Joomla core.
 - Review: backend-uncompressed.js
+2017.09.11:
+- New parameter fallback_css and fallback_js
 </versionHistory>
  <description>PLG_SYSTEM_JSCSSMINIFYGHSVS_XML_DESCRIPTION</description>
 
@@ -108,7 +110,14 @@
     <field type="text" name="extender_prefix_js" default=".min"
      label="PLG_SYSTEM_JSCSSMINIFYGHSVS_EXTENDER_PREFIX"
      description="PLG_SYSTEM_JSCSSMINIFYGHSVS_EXTENDER_PREFIX_DESC" />
-    
+
+    <field type="list" name="fallback_js" default="0"
+     label="PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK"
+     description="PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK_DESC">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
+
     <field name="js" type="subform" min="1" max="100" multiple="true"
      formsource="plugins/system/jscssminifyghsvs/myforms/jscss-subform.xml" 
      layout="joomla.form.field.subform.repeatable" groupByFieldset="false"
@@ -123,6 +132,13 @@
     <field type="text" name="extender_prefix_css" default=".min"
      label="PLG_SYSTEM_JSCSSMINIFYGHSVS_EXTENDER_PREFIX"
      description="PLG_SYSTEM_JSCSSMINIFYGHSVS_EXTENDER_PREFIX_DESC" />
+
+    <field type="list" name="fallback_css" default="0"
+     label="PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK"
+     description="PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK_DESC">
+      <option value="0">JNO</option>
+      <option value="1">JYES</option>
+    </field>
 
     <field name="css" type="subform" min="1" max="100" multiple="true"
      formsource="plugins/system/jscssminifyghsvs/myforms/jscss-subform.xml" 

--- a/language/de-DE/de-DE.plg_system_jscssminifyghsvs.ini
+++ b/language/de-DE/de-DE.plg_system_jscssminifyghsvs.ini
@@ -81,8 +81,7 @@ PLG_SYSTEM_JSCSSMINIFYGHSVS_NO_FILES_ENTERED="* Keine Quell-Dateien in Tabulator
 
 PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY="* Job abgebrochen! Der Online-Dienst <code>%s</code> gab ein leeres Ergebnis für Datei <code>%s</code> zurück. Sind Sie online? Sie müssen mit dem WWW verbunden sein! Ist die Quelldatei leer oder enthält nur Kommentare?"
 
+PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY_FALLBACK="** <strong>ABER die Fallback-Option ist aktiviert. Also wird fortgefahren und der <u>unkomprimierte</u> Quellen-Inhalt in die Zieldatei kopiert!!</strong>"
 
-
-
-
-
+PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK="Fallback"
+PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK_DESC="Wenn der Online-Service einen Fehler zurückgibt (leere Datei), dann den Quelleninhalt unkomprimiert in die Zieldatei kopieren. Fehler können bspw. bei lokalen Installationen unter XAMPP vorkommen."

--- a/language/en-GB/en-GB.plg_system_jscssminifyghsvs.ini
+++ b/language/en-GB/en-GB.plg_system_jscssminifyghsvs.ini
@@ -80,8 +80,9 @@ PLG_SYSTEM_JSCSSMINIFYGHSVS_NO_FILES_ENTERED="* No files in field %s entered. No
 
 PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY="* Job skipped! Server <code>%s</code> returned an empty result for file <code>%s</code>. Are you online? You must be connected to WWW! Is source file empty? Only comments in it?"
 
+PLG_SYSTEM_JSCSSMINIFYGHSVS_RETURNED_EMPTY_FALLBACK="** <strong>BUT fallback behavior is activated. So I will continue with <u>uncompressed</u> source content and will copy it to target!!</strong>"
+
 PLG_SYSTEM_JSCSSMINIFYGHSVS_SPACERTHANKS="<legend>T*h*x*!</legend><p>This Joomla plugin...</p><p>...is using a function getMinified() of <a href="_QQ_"https://github.com/promatik/PHP-JS-CSS-Minifier/blob/master/minifier.php"_QQ_" target=_blank>github.com/promatik/PHP-JS-CSS-Minifier/blob/master/minifier.php</a> provided by <strong style="_QQ_"color:red;"_QQ_">Toni Almeida</strong>.</p><p>...is using Subform form field from <a href="_QQ_"https://github.com/joomla/joomla-cms/pull/7829"_QQ_" target=_blank>github.com/joomla/joomla-cms/pull/7829</a> provided by <strong style="_QQ_"color:red;"_QQ_">Fedir Zinchuk (Fedik)</strong>.</p><p>...is using online webservices from <a href="_QQ_"//javascript-minifier.com"_QQ_" target=_blank>javascript-minifier.com</a> and <a href="_QQ_"//cssminifier.com"_QQ_" target=_blank>cssminifier.com</a>. These services are provided by <strong style="_QQ_"color:red;"_QQ_">Andy Chilton</strong>, <a href="_QQ_"http://chilts.org/"_QQ_" target=_blank>chilts.org</a></p>"
 
-
-
-
+PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK="Fallback"
+PLG_SYSTEM_JSCSSMINIFYGHSVS_FALLBACK_DESC="If the online service returns an error (empty file) copy unprocessed source content to target. Errors may occur on local installations like XAMPP."


### PR DESCRIPTION
https://github.com/GHSVS-de/plg_system_jscssminifyghsvs/issues/3

Under some circumstances (we saw it with XAMPP on a local WIN machine) the online services send back empty results. This PR provides new parameters fallback_css and fallback_js. If activated the plugin will copy the unprocessed source file content to the target file anyway. You'll see a message accordingly.

The fallback will also happen if:

- You are not online (not connected to WWW).
- If source file is empty.
- If source file only contains comments.